### PR TITLE
Add a test plan

### DIFF
--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -7,6 +7,22 @@ This document outlines the implementation plan for hardening the Newgame project
 
 **🚀 QUICK WINS**: Look for tasks marked with `🚀 QUICK-WIN-#` for immediate implementation with minimal setup cost.
 
+**Status Legend**:
+- ✅ **COMPLETED** - Task is done and tested
+- 🟢 **READY** - All dependencies met, ready to start
+- 🟡 **BLOCKED** - Waiting for dependencies to be completed
+- ⚪ **NOT STARTED** - Not yet prioritized for implementation
+
+**📝 IMPORTANT: Keep This Document Updated!**
+When you complete a task:
+1. Change status from 🟢 **READY** → ✅ **COMPLETED**
+2. Update all task checkboxes from `[ ]` to `[x]`
+3. Add completion notes with implementation details
+4. Update dependent tasks to 🟢 **READY** if all their dependencies are now complete
+5. Consider updating runtime estimates if actual time differed significantly
+
+This keeps the document current and helps the next developer know what's available to work on!
+
 ---
 
 ## 🚀 IMMEDIATE ACTION: Quick Wins for Local Build Validation


### PR DESCRIPTION
On the heels of my restructuring of the project, I figured it'd be good to have better ways of ensuring things work as changes come in. I threw copilot at it, so probably significantly more than we need.. Maybe I should ask for a more naive and immediate solution?

[edit] Updated doc with "quick win" tasks - less long-term infra work that can be implemented now.